### PR TITLE
Fix holesky image ref

### DIFF
--- a/src/components/Timeline/tabData.ts
+++ b/src/components/Timeline/tabData.ts
@@ -60,6 +60,6 @@ export const tabContent = [
     id: "5",
     year: "2023",
     caption: "Lodestar proposes the first block on the new 1.4M validator public testnet, Holesky",
-    imgUrl: "/holesky.png"
+    imgUrl: "/holesky-dark.png"
   },
 ];


### PR DESCRIPTION
Noticed image is not showing due to broken ref

![image](https://github.com/ChainSafe/lodestar-website/assets/38436224/ab03cf31-1ffb-4414-989d-07796f680575)
