### PR TITLE
Fix href to good first issues on github

### DIFF
--- a/src/components/Contributors/index.tsx
+++ b/src/components/Contributors/index.tsx
@@ -25,7 +25,7 @@ export const Contributors: React.FC = () => {
             </p>
             <div className="button-group">
               <a
-                href="https://github.com/ChainSafe/lodestar/labels/meta-good-first-issue"
+                href="https://github.com/ChainSafe/lodestar/labels/good%20first%20issue"
                 target="__blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
Current link does not list the issues as the label was renamed

![image](https://github.com/ChainSafe/lodestar-website/assets/38436224/7ad42e80-8832-4999-9759-59e5f0d93805)
